### PR TITLE
Fix building scripts

### DIFF
--- a/scripts/Dockerfiles/jfs_build_ubuntu_16.04.Dockerfile
+++ b/scripts/Dockerfiles/jfs_build_ubuntu_16.04.Dockerfile
@@ -3,7 +3,7 @@ FROM ${BASE_IMAGE}
 LABEL maintainer "dan@su-root.co.uk"
 
 # Install lit
-RUN curl "https://bootstrap.pypa.io/get-pip.py" -o "get-pip.py" && \
+RUN curl "https://bootstrap.pypa.io/pip/3.5/get-pip.py" -o "get-pip.py" && \
   sudo python3 get-pip.py && \
   sudo pip install lit==0.5.0
 

--- a/scripts/dist/build_llvm.sh
+++ b/scripts/dist/build_llvm.sh
@@ -11,11 +11,11 @@ set -o pipefail
 # Set values if not already set externally
 LLVM_CMAKE_GENERATOR="${LLVM_CMAKE_GENERATOR:-Ninja}"
 LLVM_BRANCH=release_60
-LLVM_GIT_URL="${LLVM_GIT_URL:-http://llvm.org/git/llvm.git}"
-CLANG_GIT_URL="${CLANG_GIT_URL:-http://llvm.org/git/clang.git}"
-COMPILER_RT_GIT_URL="${COMPILER_RT_GIT_URL:-http://llvm.org/git/compiler-rt.git}"
-LIBCXX_GIT_URL="${LIBCXX_GIT_URL:-http://git.llvm.org/git/libcxx.git}"
-LIBCXXABI_GIT_URL="${LIBCXXABI_GIT_URL:-http://git.llvm.org/git/libcxxabi.git}"
+LLVM_GIT_URL="${LLVM_GIT_URL:-https://github.com/llvm-mirror/llvm.git}"
+CLANG_GIT_URL="${CLANG_GIT_URL:-https://github.com/llvm-mirror/clang.git}"
+COMPILER_RT_GIT_URL="${COMPILER_RT_GIT_URL:-https://github.com/llvm-mirror/compiler-rt.git}"
+LIBCXX_GIT_URL="${LIBCXX_GIT_URL:-https://github.com/llvm-mirror/libcxx.git}"
+LIBCXXABI_GIT_URL="${LIBCXXABI_GIT_URL:-https://github.com/llvm-mirror/libcxxabi.git}"
 
 ADDITIONAL_LLVM_OPTS=()
 

--- a/scripts/dist/build_z3.sh
+++ b/scripts/dist/build_z3.sh
@@ -26,7 +26,7 @@ fi
 mkdir -p "${Z3_SRC_DIR}"
 git clone "${Z3_GIT_URL}" "${Z3_SRC_DIR}"
 cd "${Z3_SRC_DIR}"
-git checkout "${Z3_GIT_REVISION}"
+git reset --hard "${Z3_GIT_REVISION}"
 
 # Make build tree
 mkdir -p "${Z3_BUILD_DIR}"


### PR DESCRIPTION
Hi :wave:

I attempted to build the project using Docker (`scripts/Dockerfiles/build.sh`) and encountered some issues. This pull request addresses the following problems:

1. Ubuntu 16.04 does not support the latest version of pip. This pull request updates the pip version to one that is supported.
2. The scripts were using LLVM repositories that are no longer available. This pull request modifies the URL to point to a mirror of the pre-monorepo repositories.
3. During Z3 cloning, the script encounters issues with uncommitted changes caused by GIT modifying source code due to line encoding. This pull request adjusts the script for a successful checkout despite these changes.

Best regards,
Manuel
